### PR TITLE
add custom syslog logback config example

### DIFF
--- a/logback_custom_syslog.xml
+++ b/logback_custom_syslog.xml
@@ -1,0 +1,17 @@
+<configuration>
+  <property name="ident" value="example" scope="context"/>
+
+  <appender name="SYSLOG" class="com.spotify.logging.logback.MillisecondPrecisionSyslogAppender">
+    <syslogHost>localhost</syslogHost>
+    <facility>LOCAL0</facility>
+    <suffixPattern>%date{HH:mm:ss.SSS} %property{ident}[%property{pid}]: %-5level [%thread] %logger{0}: %msg%n</suffixPattern>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="SYSLOG" />
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="ASYNC"/>
+  </root>
+</configuration>

--- a/src/test/java/com/spotify/logging/example/ConfigFileExample.java
+++ b/src/test/java/com/spotify/logging/example/ConfigFileExample.java
@@ -79,5 +79,13 @@ public class ConfigFileExample {
     }
   }
 
+  /**
+   * Helper for running the example above with the custom syslog logging config file.
+   */
+  public static class CustomSyslogExampleRunner {
 
+    public static void main(final String... args) {
+      ConfigFileExample.main("--logconfig", "logback_custom_syslog.xml");
+    }
+  }
 }


### PR DESCRIPTION
Add an example showing how to use our `MillisecondPrecisionSyslogAppender` in a custom `logback.xml`.