### PR TITLE
Moving from deprecated raven-logback to sentry.io 1.4.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>logging</artifactId>
-  <version>2.2.3-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>logging</name>
@@ -79,9 +79,9 @@
       <version>0.6</version>
     </dependency>
     <dependency>
-      <groupId>com.getsentry.raven</groupId>
-      <artifactId>raven-logback</artifactId>
-      <version>7.8.2</version>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-logback</artifactId>
+      <version>1.4.0</version>
     </dependency>
 
     <!--test scope-->

--- a/src/main/java/com/spotify/logging/LoggingConfigurator.java
+++ b/src/main/java/com/spotify/logging/LoggingConfigurator.java
@@ -32,9 +32,10 @@ import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
-import com.getsentry.raven.logback.SentryAppender;
 import com.google.common.base.Charsets;
 import com.spotify.logging.logback.MillisecondPrecisionSyslogAppender;
+import io.sentry.Sentry;
+import io.sentry.logback.SentryAppender;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import org.slf4j.LoggerFactory;
@@ -230,8 +231,8 @@ public class LoggingConfigurator {
 
     final LoggerContext context = rootLogger.getLoggerContext();
 
+    Sentry.init(dsn);
     SentryAppender appender = new SentryAppender();
-    appender.setDsn(dsn);
 
     appender.setContext(context);
     ThresholdFilter levelFilter = new ThresholdFilter();


### PR DESCRIPTION
Followed the migration guide:
https://docs.sentry.io/clients/java/migration/
