### PR TITLE
Change timestamp key to time to resolve issues with fluentd

### DIFF
--- a/src/main/java/com/spotify/logging/logback/CustomLogstashEncoder.java
+++ b/src/main/java/com/spotify/logging/logback/CustomLogstashEncoder.java
@@ -18,7 +18,7 @@ public class CustomLogstashEncoder extends LogstashEncoder {
 
   public CustomLogstashEncoder setupStackdriver() {
     // Setup fields according to https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
-    logstashFieldNames.setTimestamp("timestamp");
+    logstashFieldNames.setTimestamp("time");
     logstashFieldNames.setLevel("severity");
     this.setFieldNames(logstashFieldNames);
     return this;


### PR DESCRIPTION
Fluentd in GKE expects `timestamp` to be an object of seconds and nseconds and expects `time` to be an iso8601 timestamp, as this is logging.