### PR TITLE
[Security] Allow replacement of newlines in the messages

### DIFF
--- a/src/main/java/com/spotify/logging/logback/SpotifyInternalAppender.java
+++ b/src/main/java/com/spotify/logging/logback/SpotifyInternalAppender.java
@@ -28,6 +28,8 @@ public class SpotifyInternalAppender extends MillisecondPrecisionSyslogAppender 
 
   private boolean portConfigured = false;
 
+  private LoggingConfigurator.ReplaceNewLines replaceNewLines = LoggingConfigurator.ReplaceNewLines.OFF;
+
   @Override
   public void start() {
     Preconditions.checkState(serviceName != null, "serviceName must be configured");
@@ -38,7 +40,7 @@ public class SpotifyInternalAppender extends MillisecondPrecisionSyslogAppender 
     // our internal syslog-ng configuration splits logs up based on service name, and expects the
     // format below.
     String serviceAndPid = String.format("%s[%s]", serviceName, getMyPid());
-    setSuffixPattern(serviceAndPid + ": %msg");
+    setSuffixPattern(serviceAndPid + ": " + LoggingConfigurator.ReplaceNewLines.getMsgPattern(this.replaceNewLines));
     setStackTracePattern(serviceAndPid + ": " + CoreConstants.TAB);
 
     if (getSyslogHost() == null) {
@@ -77,6 +79,10 @@ public class SpotifyInternalAppender extends MillisecondPrecisionSyslogAppender 
    */
   public void setServiceName(String serviceName) {
     this.serviceName = serviceName;
+  }
+
+  public void setReplaceNewLines(LoggingConfigurator.ReplaceNewLines replaceNewLines) {
+    this.replaceNewLines = replaceNewLines;
   }
 
   // copied from LoggingConfigurator to avoid making public and exposing externally.

--- a/src/test/java/com/spotify/logging/LoggingConfiguratorTest.java
+++ b/src/test/java/com/spotify/logging/LoggingConfiguratorTest.java
@@ -19,6 +19,7 @@ package com.spotify.logging;
 import static com.spotify.logging.LoggingConfigurator.getSyslogAppender;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -37,22 +38,36 @@ public class LoggingConfiguratorTest {
   public void testGetSyslogAppender() {
     final LoggerContext context = new LoggerContext();
 
-    SyslogAppender appender = (SyslogAppender) getSyslogAppender(context, "", -1);
+    SyslogAppender appender = (SyslogAppender) getSyslogAppender(context, "", -1, LoggingConfigurator.ReplaceNewLines.OFF);
     assertEquals("wrong host", "localhost", appender.getSyslogHost());
     assertEquals("wrong port", 514, appender.getPort());
 
-    appender = (SyslogAppender) getSyslogAppender(context, null, -1);
+    appender = (SyslogAppender) getSyslogAppender(context, null, -1, LoggingConfigurator.ReplaceNewLines.OFF);
     assertEquals("wrong host", "localhost", appender.getSyslogHost());
     assertEquals("wrong port", 514, appender.getPort());
 
-    appender = (SyslogAppender) getSyslogAppender(context, "host", -1);
+    appender = (SyslogAppender) getSyslogAppender(context, "host", -1, LoggingConfigurator.ReplaceNewLines.OFF);
     assertEquals("wrong host", "host", appender.getSyslogHost());
     assertEquals("wrong port", 514, appender.getPort());
 
-    appender = (SyslogAppender) getSyslogAppender(context, null, 999);
+    appender = (SyslogAppender) getSyslogAppender(context, null, 999, LoggingConfigurator.ReplaceNewLines.OFF);
     assertEquals("wrong host", "localhost", appender.getSyslogHost());
     assertEquals("wrong port", 999, appender.getPort());
 
+  }
+
+  @Test
+  public void testGetSyslogAppenderRespectsNewLineReplacement() {
+    final LoggerContext context = new LoggerContext();
+
+    SyslogAppender appender = (SyslogAppender) getSyslogAppender(context, "", -1, LoggingConfigurator.ReplaceNewLines.OFF);
+    assertEquals("%property{ident}[%property{pid}]: %msg", appender.getSuffixPattern());
+
+    appender = (SyslogAppender) getSyslogAppender(context, "", -1, null);
+    assertEquals("%property{ident}[%property{pid}]: %msg", appender.getSuffixPattern());
+
+    appender = (SyslogAppender) getSyslogAppender(context, "", -1, LoggingConfigurator.ReplaceNewLines.ON);
+    assertEquals("%property{ident}[%property{pid}]: %replace(%msg){'[\\r\\n]', ''}", appender.getSuffixPattern());
   }
 
   private String getLoggingContextHostnameProperty() {

--- a/src/test/java/com/spotify/logging/example/SimpleConsoleExample.java
+++ b/src/test/java/com/spotify/logging/example/SimpleConsoleExample.java
@@ -32,7 +32,7 @@ public class SimpleConsoleExample {
 
   public static void main(final String... args) {
 
-    LoggingConfigurator.configureDefaults("example", INFO);
+    LoggingConfigurator.configureDefaults("example", INFO, LoggingConfigurator.ReplaceNewLines.ON);
 
     while (true) {
       // Should not be logged
@@ -42,7 +42,7 @@ public class SimpleConsoleExample {
       logger.debug("debug!");
       logger.info("info!");
       logger.warn("warn!");
-      logger.error("error!", new Exception("failure"));
+      logger.error("\nerror!\n", new Exception("failure"));
 
       try {
         Thread.sleep(1000);


### PR DESCRIPTION
This PR enables configuration of new line replacement in the logged messages.
It addresses a security issue you can read here more about https://find-sec-bugs.github.io/bugs.htm#CRLF_INJECTION_LOGS 