### PR TITLE
add arguments json provider + tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
       <version>1.16.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.11.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/spotify/logging/LoggingConfigurator.java
+++ b/src/main/java/com/spotify/logging/LoggingConfigurator.java
@@ -38,6 +38,7 @@ import com.spotify.logging.logback.CustomLogstashEncoder;
 import com.spotify.logging.logback.MillisecondPrecisionSyslogAppender;
 import java.io.File;
 import java.lang.management.ManagementFactory;
+import net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -216,6 +217,7 @@ public class LoggingConfigurator {
 
     final CustomLogstashEncoder encoder = new CustomLogstashEncoder().setupStackdriver();
     encoder.setContext(context);
+    encoder.addProvider(new ArgumentsJsonProvider());
     encoder.start();
 
     final ConsoleAppender<ILoggingEvent> appender = new ConsoleAppender<ILoggingEvent>();

--- a/src/test/java/com/spotify/logging/LoggingConfiguratorTest.java
+++ b/src/test/java/com/spotify/logging/LoggingConfiguratorTest.java
@@ -26,8 +26,15 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.net.SyslogAppender;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.encoder.Encoder;
+import com.google.common.collect.FluentIterable;
 import com.spotify.logging.logback.CustomLogstashEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import net.logstash.logback.composite.JsonProvider;
+import net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -150,6 +157,11 @@ public class LoggingConfiguratorTest {
     final ConsoleAppender<?> stdout = (ConsoleAppender<?>) rootLogger.getAppender("stdout");
     assertTrue(stdout.getEncoder() instanceof CustomLogstashEncoder);
     assertEquals(level, rootLogger.getLevel());
+    final CustomLogstashEncoder encoder = (CustomLogstashEncoder) stdout.getEncoder();
+    assertEquals(1, FluentIterable
+        .from(encoder.getProviders().getProviders())
+        .filter(ArgumentsJsonProvider.class)
+        .size());
   }
 
   private void assertDefault(final String ident, final Level level) {

--- a/src/test/java/com/spotify/logging/logback/LogstashEncoderTest.java
+++ b/src/test/java/com/spotify/logging/logback/LogstashEncoderTest.java
@@ -1,0 +1,75 @@
+package com.spotify.logging.logback;
+
+import static net.logstash.logback.argument.StructuredArguments.value;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.spotify.logging.LoggingConfigurator;
+import com.spotify.logging.LoggingConfigurator.Level;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogstashEncoderTest {
+
+  private static final Logger log = LoggerFactory.getLogger(LogstashEncoder.class);
+
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  @Rule
+  public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+  @Test
+  public void shouldIncludeStructuredArguments() throws JsonProcessingException {
+    LoggingConfigurator.configureLogstashEncoderDefaults(Level.INFO);
+    log.info("foo={} bar={} list={} map={} thing={}",
+        value("foo", 17),
+        value("bar", "quux"),
+        value("list", ImmutableList.of(1, 2)),
+        value("map", ImmutableMap.of("a", 3, "b", 4)),
+        value("thing", new Thing(5, "6")));
+    final String log = systemOutRule.getLog();
+    final JsonNode parsedMessage = mapper.readTree(log);
+    assertEquals("foo=17 bar=quux list=[1, 2] map={a=3, b=4} thing=Thing{v1=5, v2='6'}",
+        parsedMessage.get("message").asText());
+    assertEquals(17, parsedMessage.get("foo").asInt());
+    assertEquals("quux", parsedMessage.get("bar").asText());
+    assertEquals(mapper.createArrayNode().add(1).add(2), parsedMessage.get("list"));
+    assertEquals(mapper.createObjectNode().put("a", 3).put("b", 4), parsedMessage.get("map"));
+    assertEquals(mapper.createObjectNode().put("v1", 5).put("v2", "6"), parsedMessage.get("thing"));
+  }
+
+  public static class Thing {
+
+    private final int v1;
+    private final String v2;
+
+    public Thing(int v1, String v2) {
+      this.v1 = v1;
+      this.v2 = v2;
+    }
+
+    public int getV1() {
+      return v1;
+    }
+
+    public String getV2() {
+      return v2;
+    }
+
+    @Override
+    public String toString() {
+      return "Thing{" +
+          "v1=" + v1 +
+          ", v2='" + v2 + '\'' +
+          '}';
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/spotify/logging-java/pull/28 with tests

I have gone through our internal code base to find [`StructuredArguments`](https://github.com/logstash/logstash-logback-encoder/blob/master/src/main/java/net/logstash/logback/argument/StructuredArguments.java) users that would observe a behavior change. For the few I could find it seems impact would be harmless.

For more context, this behavior change means that `StructuredArgument` values will be jackson serialized, meaning that e.g. getters will be called. This is normally fine for small data values but could have negative impact for large values or complex objects where the getter was actually a method with a side-effect. I did not manage to find any such call sites.