### PR TITLE
Bumps logback 1.2.3 -> 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.8</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.8</version>
     </dependency>
     <dependency>
       <groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
Logback also can be affected by the exploit that log4j2 has been.

Although very unlikely as to exploit logback you need extra steps
(namely write access to logback.xml and being able to restart
the application), it's better be safe than sorry.

More info at logback news:
http://logback.qos.ch/news.html