### PR TITLE
Update SentryAppender to use sentry-logback dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
       <version>0.6</version>
     </dependency>
     <dependency>
-      <groupId>com.getsentry.raven</groupId>
-      <artifactId>raven-logback</artifactId>
-      <version>7.8.2</version>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-logback</artifactId>
+      <version>6.11.0</version>
     </dependency>
 
     <!--test scope-->

--- a/src/main/java/com/spotify/logging/LoggingConfigurator.java
+++ b/src/main/java/com/spotify/logging/LoggingConfigurator.java
@@ -50,9 +50,10 @@ import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
-import com.getsentry.raven.logback.SentryAppender;
 import com.spotify.logging.logback.CustomLogstashEncoder;
 import com.spotify.logging.logback.MillisecondPrecisionSyslogAppender;
+import io.sentry.SentryOptions;
+import io.sentry.logback.SentryAppender;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
@@ -341,7 +342,9 @@ public class LoggingConfigurator {
     final LoggerContext context = rootLogger.getLoggerContext();
 
     SentryAppender appender = new SentryAppender();
-    appender.setDsn(dsn);
+    SentryOptions sentryOptions = new SentryOptions();
+    sentryOptions.setDsn(dsn);
+    appender.setOptions(sentryOptions);
 
     appender.setContext(context);
     ThresholdFilter levelFilter = new ThresholdFilter();


### PR DESCRIPTION
The raven dependencies are now considered legacy and should be migrated to the new sentry-* dependencies. This dependency is used to setup the SentryAppender.