### PR TITLE
MinimumEventLevel is ERROR, needs to be configured to log lower levels

### DIFF
--- a/src/main/java/com/spotify/logging/LoggingConfigurator.java
+++ b/src/main/java/com/spotify/logging/LoggingConfigurator.java
@@ -37,6 +37,7 @@
 package com.spotify.logging;
 
 import static ch.qos.logback.classic.Level.OFF;
+import static ch.qos.logback.classic.Level.WARN;
 import static java.lang.System.getenv;
 
 import ch.qos.logback.classic.Logger;
@@ -366,6 +367,7 @@ public class LoggingConfigurator {
     ThresholdFilter levelFilter = new ThresholdFilter();
     levelFilter.setLevel(logLevelThreshold.logbackLevel.toString());
     levelFilter.start();
+    appender.setMinimumEventLevel(logLevelThreshold.logbackLevel);
     appender.addFilter(levelFilter);
 
     appender.start();

--- a/src/main/java/com/spotify/logging/LoggingConfigurator.java
+++ b/src/main/java/com/spotify/logging/LoggingConfigurator.java
@@ -37,7 +37,6 @@
 package com.spotify.logging;
 
 import static ch.qos.logback.classic.Level.OFF;
-import static ch.qos.logback.classic.Level.WARN;
 import static java.lang.System.getenv;
 
 import ch.qos.logback.classic.Logger;


### PR DESCRIPTION
MinimumEventLevel is defaulting to ERROR and needs to be configured to log lower levels such as WARN.